### PR TITLE
fix(fov): Remove Bresenham line artifacts in FOV calculation

### DIFF
--- a/Packages/za.co.lazygamedev.rogue-dots/LazyGameDevZA.RogueDOTS.Toolkit.Tests/FOVTests.cs
+++ b/Packages/za.co.lazygamedev.rogue-dots/LazyGameDevZA.RogueDOTS.Toolkit.Tests/FOVTests.cs
@@ -1,5 +1,4 @@
-﻿using LazyGameDevZA.RogueDOTS.Toolkit;
-using LazyGameDevZA.RogueDOTS.Toolkit.Collections;
+﻿using LazyGameDevZA.RogueDOTS.Toolkit.Collections;
 using NUnit.Framework;
 using Unity.Collections;
 using Unity.Mathematics;
@@ -17,12 +16,69 @@ namespace LazyGameDevZA.RogueDOTS.Toolkit.Tests
         {
             public NativeArray<bool> Tiles;
         }
+        
+        private static int xy_idx(int x, int y)
+        {
+            return y * testMapW + x;
+        }
+
+        private static int2 positionFromText(string template)
+        {
+            var y = 0;
+            foreach (var line in template.Split('\n'))
+            {
+                var x = 0;
+                foreach (var ch in line.ToCharArray())
+                {
+                    if (ch == '@')
+                    {
+                        return new int2(x, y);
+                    }
+
+                    x++;
+                }
+
+                y++;
+            }
+
+            return new int2(0,0);
+        }
 
         private partial struct Map
         {
             public static Map New()
             {
                 return new Map { Tiles = new NativeArray<bool>(testMapTiles, Allocator.Temp) };
+            }
+
+            public static Map FromText(string template)
+            {
+                var result = New();
+                var y = 0;
+
+                foreach (var line in template.Split('\n'))
+                {
+                    var x = 0;
+                    foreach (var ch in line.ToCharArray())
+                    {
+                        switch (ch)
+                        {
+                            case '#':
+                            case ' ':
+                                result.Tiles[xy_idx(x, y)] = true;
+                                break;
+                            default:
+                                result.Tiles[xy_idx(x, y)] = false;
+                                break;
+                        }
+                         
+                        x++;
+                    }
+
+                    y++;
+                }
+
+                return result;
             }
         }
 
@@ -91,6 +147,45 @@ namespace LazyGameDevZA.RogueDOTS.Toolkit.Tests
                 Assert.That(t.y > 0);
                 Assert.That(t.y < testMapH);
             }
+        }
+
+        [Test]
+        public void FOVHasNoDeadSpots()
+        {
+            /*
+             * This is not a very good test... it was arrived at by manually testing behaviour in Unity until it
+             * was acceptable and then pegging the number of visible tiles in the test scenario. It was good enough
+             * to at least detect when my refactor broke the current behaviour, so leaving it in for now.
+             *
+             * It would be better if:
+             *  - there was a nicer way to load the test scenario
+             *  - a way to visualise the output of the FOV code in test output
+             */
+            var testMap = 
+@"
+       .      
+       .      
+       .      
+      #.#
+      #.#      
+      #.#
+   ####.#####
+   #........#
+   #...@....#
+   #........#
+   #........#
+   #........#
+ ...............
+####........#...
+   ##########
+";
+            var position = positionFromText(testMap);
+            var range = 8;
+            var map = Map.FromText(testMap);
+            
+            var visible = FieldOfView(position, range, map);
+
+            Assert.AreEqual(108, visible.Length);
         }
     }
 }

--- a/Packages/za.co.lazygamedev.rogue-dots/LazyGameDevZA.RogueDOTS.Toolkit/FOV.cs
+++ b/Packages/za.co.lazygamedev.rogue-dots/LazyGameDevZA.RogueDOTS.Toolkit/FOV.cs
@@ -8,9 +8,10 @@ namespace LazyGameDevZA.RogueDOTS.Toolkit
     public static class FOV
     {
         // TODO Map might be switched out for an interface if possible
-        public static NativeHashSet<int2> FieldOfViewSet<T>(int2 start, int range, in T fovCheck) where T: IAlgorithm2D, IBaseMap
+        public static NativeHashSet<int2> FieldOfViewSet<T>(int2 start, int range, in T fovCheck)
+            where T : IAlgorithm2D, IBaseMap
         {
-            var visiblePoints = new NativeHashSet<int2>( range * 2 * range * 2, Allocator.Temp);
+            var visiblePoints = new NativeHashSet<int2>(range * 2 * range * 2, Allocator.Temp);
 
             var iterator = new BresenhamCircleNoDiag(start, range).GetEnumerator();
             
@@ -18,28 +19,74 @@ namespace LazyGameDevZA.RogueDOTS.Toolkit
             {
                 ScanFovLine(start, iterator.Current, fovCheck, ref visiblePoints);
             }
-            
+
             iterator.Dispose();
+
+            PostProcessToRemoveBresenhamArtifacts(start, range, fovCheck, visiblePoints);
 
             return visiblePoints;
         }
-        
-        public static NativeArray<int2> FieldOfView<T>(int2 start, int range, in T fovCheck) where T: IAlgorithm2D, IBaseMap
+
+        private static void PostProcessToRemoveBresenhamArtifacts<T>(int2 start, int range, in T fovCheck,
+            NativeHashSet<int2> visiblePoints) where T : IAlgorithm2D, IBaseMap
+        {
+            RemoveBresenhamArtifactsInDirection(start, new int2(-1, -1), range, fovCheck, visiblePoints);
+            RemoveBresenhamArtifactsInDirection(start, new int2(+1, -1), range, fovCheck, visiblePoints);
+            RemoveBresenhamArtifactsInDirection(start, new int2(-1, +1), range, fovCheck, visiblePoints);
+            RemoveBresenhamArtifactsInDirection(start, new int2(+1, +1), range, fovCheck, visiblePoints);
+        }
+
+        private static void RemoveBresenhamArtifactsInDirection<T>(
+            int2 start,
+            int2 direction,
+            int range,
+            in T fovCheck,
+            NativeHashSet<int2> visiblePoints) where T : IAlgorithm2D, IBaseMap
+        {
+            for (var i = 0; i <= range + 1; i++)
+            {
+                var x = start.x + i * direction.x;
+                for (var j = 0; j <= range + 1; j++)
+                {
+                    var y = start.y + j * direction.y;
+                    
+                    var current = new int2(x, y);
+                    var isWall = fovCheck.Inbounds(current) && fovCheck.IsOpaque(fovCheck.point2DToIndex(current));
+                    var horizontalInFront = new int2(x - direction.x, y);
+                    var verticalInFront = new int2(x, y - direction.y);
+                    var horizontalInFrontIsLitGround = fovCheck.Inbounds(horizontalInFront) && 
+                                          !fovCheck.IsOpaque(fovCheck.point2DToIndex(horizontalInFront)) &&
+                                          visiblePoints.Contains(horizontalInFront);
+                    var verticalInFrontIsLitGround = fovCheck.Inbounds(verticalInFront) &&
+                                           !fovCheck.IsOpaque(fovCheck.point2DToIndex(verticalInFront)) &&
+                                           visiblePoints.Contains(verticalInFront);
+
+                    if (isWall && (verticalInFrontIsLitGround || horizontalInFrontIsLitGround))
+                    {
+                        visiblePoints.TryAdd(current);
+                    }
+                }
+            }
+        }
+
+        public static NativeArray<int2> FieldOfView<T>(int2 start, int range, in T fovCheck)
+            where T : IAlgorithm2D, IBaseMap
         {
             return FieldOfViewSet(start, range, fovCheck).ToNativeArray();
         }
 
-        private static void ScanFovLine<T>(int2 start, int2 end, in T fovCheck, ref NativeHashSet<int2> visiblePoints) where T : IAlgorithm2D, IBaseMap
+        private static void ScanFovLine<T>(int2 start, int2 end, in T fovCheck, ref NativeHashSet<int2> visiblePoints)
+            where
+            T : IAlgorithm2D, IBaseMap
         {
             var line = VectorLine.New(start, end);
-
             var iterator = line.GetEnumerator();
+
             int2 target;
-            
-            while(iterator.MoveNext())
+            while (iterator.MoveNext())
             {
                 target = iterator.Current;
-                if(!fovCheck.Inbounds(target))
+                if (!fovCheck.Inbounds(target))
                 {
                     // We're outside the map
                     break;
@@ -47,13 +94,13 @@ namespace LazyGameDevZA.RogueDOTS.Toolkit
 
                 visiblePoints.TryAdd(target);
 
-                if(fovCheck.IsOpaque(fovCheck.point2DToIndex(target)))
+                if (fovCheck.IsOpaque(fovCheck.point2DToIndex(target)))
                 {
                     //FOV is blocked
                     break;
                 }
             }
-            
+
             iterator.Dispose();
         }
     }


### PR DESCRIPTION
Relatively simple postprocessing based on the algorithm described here:
https://sites.google.com/site/jicenospam/visibilitydetermination

Apologies for the formatting changes... I should maybe get your Rider settings from you?

fixes #1